### PR TITLE
[Android] Support arguments from Activity Monitor.

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/AssetCopyService.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/AssetCopyService.java
@@ -36,7 +36,7 @@ public final class AssetCopyService extends IntentService
 	@Override
 	protected void onHandleIntent(Intent intent)
 	{
-		String BaseDir = Environment.getExternalStorageDirectory() + File.separator + "dolphin-emu";
+		String BaseDir = NativeLibrary.GetUserDirectory();
 		String ConfigDir = BaseDir + File.separator + "Config";
 		String GCDir = BaseDir + File.separator + "GC";
 

--- a/Source/Android/src/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -176,6 +176,11 @@ public final class NativeLibrary
 	public static native void SetUserDirectory(String directory);
 
 	/**
+	 * Returns the current working user directory
+	 */
+	public static native String GetUserDirectory();
+
+	/**
 	 * Begins emulation.
 	 * 
 	 * @param surf The surface to render to.

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -233,6 +233,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveState(JN
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadState(JNIEnv *env, jobject obj, jint slot);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_CreateUserFolders(JNIEnv *env, jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetUserDirectory(JNIEnv *env, jobject obj, jstring jDirectory);
+JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDirectory(JNIEnv *env, jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Run(JNIEnv *env, jobject obj, jobject _surf);
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_UnPauseEmulation(JNIEnv *env, jobject obj)
@@ -368,6 +369,11 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetUserDirec
 	std::string directory = GetJString(env, jDirectory);
 	g_set_userpath = directory;
 	UICommon::SetUserDirectory(directory);
+}
+
+JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDirectory(JNIEnv *env, jobject obj)
+{
+	return env->NewStringUTF(File::GetUserPath(D_USER_IDX).c_str());
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Run(JNIEnv *env, jobject obj, jobject _surf)


### PR DESCRIPTION
Activity Monitor can start activities by using adb to invoke it.
This will allow us to set the user directory and autostart file from adb.

adb shell am start -n org.dolphinemu.dolphinemu/.gamelist.GameListActivity -e AutoStartFile /sdcard/AC.gcz -e UserDir /sdcard/dolphin-emu2/

This allows more automated testing to be done with Dolphin on Android.
